### PR TITLE
Upgrade to upstream version 1.3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Roundcube for YunoHost
 [Roundcube](https://roundcube.net/) is a browser-based multilingual IMAP client with
 an application-like user interface.
 
-**Shipped version:** 1.2.5
+**Shipped version:** 1.3.6
 
 ![](https://roundcube.net/images/screens/mailview.jpg)
 

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/roundcube/roundcubemail/releases/download/1.3.0/roundcubemail-1.3.0.tar.gz
-SOURCE_SUM=a37e55a3b5f83420930ae20ef3ac6dbedb499c920bbcf3fc93a8f784f7773d21
+SOURCE_URL=https://github.com/roundcube/roundcubemail/releases/download/1.3.6/roundcubemail-1.3.6.tar.gz
+SOURCE_SUM=5796670080c9c3c4071eecc70ddcb6b5df98d8a241a73e8a687fd536a9410c7a
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
     },
     "url": "https://roundcube.net/",
     "license": "GPL-3",
-    "version": "1.3.0",
+    "version": "1.3.6~ynh1",
     "maintainer": {
         "name": "YunoHost Contributors",
         "email": "apps@yunohost.org"


### PR DESCRIPTION
## Problem
- Roundcube is not up-to-date and there are [security reasons](https://roundcube.net/news/2018/04/11/security-update-1.3.6) to upgrade it.

## Solution
- Upgrade to latest version 1.3.6

## PR Status
Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## Validation
Minor decision*
- [ ] **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- [ ] **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/roundcube_ynh%20enh_upgrade_1.3.6%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/roundcube_ynh%20enh_upgrade_1.3.6%20(Official)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.