### PR TITLE
#56 adding php-curl requirement

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 # =============================================================================
 
 # Package dependencies
-pkg_dependencies="php-cli php-common php-intl php-json php-mcrypt php-pear php-auth-sasl php-mail-mime php-patchwork-utf8 php-net-smtp php-net-socket php-net-ldap2 php-net-ldap3 php-zip php-gd php-mbstring"
+pkg_dependencies="php-cli php-common php-intl php-json php-mcrypt php-pear php-auth-sasl php-mail-mime php-patchwork-utf8 php-net-smtp php-net-socket php-net-ldap2 php-net-ldap3 php-zip php-gd php-mbstring php-curl"
 
 # Plugins version
 contextmenu_version=2.3


### PR DESCRIPTION
## Problem
- `php-curl` dependency was not present and is required when installing the cardav plugin

## Solution
- added the `php-curl` dependency

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [X] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : JimboJoe
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/roundcube_ynh%20PR60/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/roundcube_ynh%20PR60/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
