### PR TITLE
[buster] No php-mcrypt anymoar

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # Package dependencies
-pkg_dependencies="php-cli php-common php-intl php-json php-mcrypt php-pear php-auth-sasl php-mail-mime php-patchwork-utf8 php-net-smtp php-net-socket php-net-ldap2 php-net-ldap3 php-zip php-gd php-mbstring php-curl"
+pkg_dependencies="php-cli php-common php-intl php-json php-pear php-auth-sasl php-mail-mime php-patchwork-utf8 php-net-smtp php-net-socket php-net-ldap2 php-net-ldap3 php-zip php-gd php-mbstring php-curl"
 
 # Plugins version
 contextmenu_version=2.3


### PR DESCRIPTION
## Problem

Install fails on buster because there's no php-mcrypt anymore

## Solution

After a quick lookup on the internet, my understanding is that the stuff provided by php-mcrypt is old / deprecated since a while, and in fact Roundcube doesnt need it anymore (it was added back to the jessie or maybe even squeeze era).

So let's remove it. (N.B. : I haven't tested anything though - but it should be okay to commit this for stretch as well)

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [X] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Kay0u
- [x] **Approval (LGTM)** : Kay0u
- [x] **Approval (LGTM)** : Maniack C
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/roundcube_ynh%20PR78/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/roundcube_ynh%20PR78/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
