### PR TITLE
Upgrade to upstream version 1.4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you don't have YunoHost, please see [here](https://yunohost.org/#/install) to
 [Roundcube](https://roundcube.net/) is a browser-based multilingual IMAP client with
 an application-like user interface.
 
-**Shipped version:** 1.4.3
+**Shipped version:** 1.4.6
 
 ## Screenshots
 

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/roundcube/roundcubemail/releases/download/1.4.3/roundcubemail-1.4.3.tar.gz
-SOURCE_SUM=e04cc592025d90c4312deb0587c204a8aec13ac3f852ac8689d771655f78a1fe
+SOURCE_URL=https://github.com/roundcube/roundcubemail/releases/download/1.4.6/roundcubemail-1.4.6.tar.gz
+SOURCE_SUM=23805f8a41a9ab6c379e335fb00f885d12eabfce33beb382c30c148e76565537
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Open Source Webmail software",
         "fr": "Webmail Open Source"
     },
-    "version": "1.4.3~ynh1",
+    "version": "1.4.6~ynh1",
     "url": "https://roundcube.net/",
     "license": "GPL-3.0-only",
     "maintainer": {


### PR DESCRIPTION
## Problem
- *Upgrade to upstream version 1.4.6 because of 1.4.5 regression https://github.com/roundcube/roundcubemail/releases/tag/1.4.6*

## Solution
- *And how you fix that*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/roundcube_ynh%20PR-NUM-/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/roundcube_ynh%20PR-NUM-/)  
*Please replace '-NUM-' in this link by the PR number.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
