### PR TITLE
Force to use composer version 1.10.17

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -7,6 +7,9 @@
 # Package dependencies
 pkg_dependencies="php-cli php-common php-intl php-json php-pear php-auth-sasl php-mail-mime php-patchwork-utf8 php-net-smtp php-net-socket php-zip php-gd php-mbstring php-curl"
 
+# Composer version
+composer_version=1.10.17
+
 # Plugins version
 contextmenu_version=2.3
 automatic_addressbook_version=v0.4.3
@@ -55,7 +58,7 @@ ynh_install_composer () {
 
 	curl -sS https://getcomposer.org/installer \
 		| COMPOSER_HOME="$workdir/.composer" \
-		php${phpversion} -- --quiet --install-dir="$workdir" \
+		php${phpversion} -- --quiet --install-dir="$workdir" --version="$composer_version" \
 		|| ynh_die "Unable to install Composer."
 
 	# update dependencies to create composer.lock


### PR DESCRIPTION
Composer 2.x is breaking installation of roundcube plugins
Waiting updates of plugins, we must use composer verison 1.x

## Problem
- Install is not working with plugin roundcube/carddav
- Can't add easily plugins that have not migrated to last version of plugin-installer
- https://roundcube.net/news/2020/11/04/installer-update-for-composer-v2

## Solution
- Use last 1.x composer version
- Another solution should be to update every plugins but it could be a little more longer 😜 

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/roundcube_ynh%20PR-NUM-/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/roundcube_ynh%20PR-NUM-/)  
*Please replace '-NUM-' in this link by the PR number.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
