### PR TITLE
Fix display of login page when logged on SSO

### DIFF
--- a/sources/patches/app-fix-login-page-when-ssoed.patch
+++ b/sources/patches/app-fix-login-page-when-ssoed.patch
@@ -1,0 +1,14 @@
+diff -ruN roundcube.orig/index.php roundcube/index.php
+--- roundcube.orig/index.php	2021-04-26 14:48:33.169655413 +0200
++++ roundcube/index.php	2021-04-26 14:54:07.594479133 +0200
+@@ -210,6 +210,10 @@
+     if (!$RCMAIL->session->check_auth()) {
+         $RCMAIL->kill_session();
+         $session_error = 'sessionerror';
++        if (!empty($_SERVER['PHP_AUTH_USER'])) {
++            header('Location: https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']);
++            exit;
++        }
+     }
+ }
+ 


### PR DESCRIPTION
## Problem
- Even if we are connected with SSO, some time the roundcube session is killed and so the roundcube login page is displayed (session expired)

## Solution
- Patch roundcube : When session is killed and user logged thanks to ssowat, the page is refresh to generate to roundcube session

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 

## Package_check results
---
* An automatic package_check will be launch at https://ci-apps-dev.yunohost.org/, when you add a specific comment to your Pull Request: "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!"*
