### PR TITLE
Fix plugins urls

### DIFF
--- a/doc/DESCRIPTION.md
+++ b/doc/DESCRIPTION.md
@@ -5,6 +5,6 @@ Roundcube is a browser-based multilingual IMAP client with an application-like u
 In addition to Roundcube core features, the following are made available with this package:
 
  * Synchronize your email aliases as identities in Roundcube
- * Install the [contextmenu](https://plugins.roundcube.net/packages/johndoh/contextmenu) and [automatic addressbook](https://plugins.roundcube.net/packages/sblaisot/automatic_addressbook) plugins by default
- * Allow to install the [CardDAV](https://plugins.roundcube.net/packages/roundcube/carddav) (address book) synchronization plugin at the installation - note that if you have installed Nextcloud or Baïkal, it will automatically add the corresponding and existing address book.
+ * Install the [contextmenu](https://packagist.org/packages/johndoh/contextmenu) and [automatic addressbook](https://packagist.org/packages/projectmyst/automatic_addressbook) plugins by default
+ * Allow to install the [CardDAV](https://packagist.org/packages/roundcube/carddav) (address book) synchronization plugin at the installation - note that if you have installed Nextcloud or Baïkal, it will automatically add the corresponding and existing address book.
 * Support for PGP encryption with Enigma plugin by default.

--- a/doc/DESCRIPTION_fr.md
+++ b/doc/DESCRIPTION_fr.md
@@ -5,7 +5,7 @@ Roundcube est un client IMAP multilingue basé sur un navigateur avec une interf
 En plus des fonctionnalités principales de Roundcube, les éléments suivants sont disponibles avec ce paquet :
 
  * Synchronisez vos alias de messagerie en tant qu'identités dans Roundcube.
- * Installation des plugins [contextmenu](https://plugins.roundcube.net/packages/johndoh/contextmenu)
-   et [automatic addressbook](https://plugins.roundcube.net/packages/sblaisot/automatic_addressbook) par default.
- * Permettre d'installer [CardDAV](https://plugins.roundcube.net/packages/roundcube/carddav) (carnet d'adresses) de synchronisation à l'installation - notez que si vous avez installé Nextcloud ou Baïkal, il ajoutera automatiquement le carnet d'adresses correspondant.
+ * Installation des plugins [contextmenu](https://packagist.org/packages/johndoh/contextmenu)
+   et [automatic addressbook](https://packagist.org/packages/projectmyst/automatic_addressbook) par default.
+ * Permettre d'installer [CardDAV](https://packagist.org/packages/roundcube/carddav) (carnet d'adresses) de synchronisation à l'installation - notez que si vous avez installé Nextcloud ou Baïkal, il ajoutera automatiquement le carnet d'adresses correspondant.
 * Prise en charge du chiffrement PGP avec le plugin Enigma installé par default.

--- a/doc/DISCLAIMER.md
+++ b/doc/DISCLAIMER.md
@@ -12,7 +12,7 @@ You can also install other plugins - which will not be removed with upgrades. To
 
 ##### From the Plugin Repository
 
-Let's say for example that we want to install the [html5_notifier](https://plugins.roundcube.net/packages/kitist/html5_notifier) plugin.
+Let's say for example that we want to install the [html5_notifier](https://packagist.org/packages/kitist/html5_notifier) plugin.
 
 1. Connect to your server as root using SSH:
    ```

--- a/doc/DISCLAIMER_fr.md
+++ b/doc/DISCLAIMER_fr.md
@@ -12,7 +12,7 @@ Vous pouvez également installer d'autres plugins (qui ne seront pas supprimés 
 
 ##### Depuis le dépôt de plugins
 
-Si, par exemple, vous voulez installer le plugin [html5_notifier](https://plugins.roundcube.net/packages/kitist/html5_notifier).
+Si, par exemple, vous voulez installer le plugin [html5_notifier](https://packagist.org/packages/kitist/html5_notifier).
 
 1. Connectez-vous en SSH à votre serveur en tant que root :
    ```


### PR DESCRIPTION
Roundcube plugin repository is now hosted on The PHP Package Repository [Packagist](https://packagist.org/)