### PR TITLE
Move composer lock

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -16,6 +16,12 @@ source /usr/share/yunohost/helpers
 upgrade_type=$(ynh_check_app_version_changed)
 
 #=================================================
+# MOVE COMPOSER LOCK TO BACK IT UP
+#=================================================
+
+mv /var/www/roundcube/composer.lock /var/www/roundcube/composer.lock.bak
+
+#=================================================
 # ENSURE DOWNWARD COMPATIBILITY
 #=================================================
 ynh_script_progression --message="Ensuring downward compatibility..." --weight=1


### PR DESCRIPTION
## Problem

- *Failed upgrade from 1.6.0 ynh4 to 1.6.6 ynh1*

## Solution

- *A solution is to move the file /var/www/roundcube/composer.lock somewhere else in order to back it up if needed*
`mv /var/www/roundcube/composer.lock /var/www/roundcube/composer.lock.bak`
https://forum.yunohost.org/t/roundcube-a-webmail/3965/71

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
