### PR TITLE
Allow custom config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,52 @@ In addition to Roundcube core features, the following are made available with th
 
 ![Screenshot of Roundcube](./doc/screenshots/screenshot.png)
 
+## Configuration
+
+You can extend - or even override - the Roundcube configuration which is coming with this package in the file `config/<ROUNDCUBE_DOMAIN>.inc.php`. Do not edit the file `config/config.inc.php` as future upgrades will overwrite it.
+
+#### Multi-users support
+
+* Integrate with YunoHost users and SSO - i.e logout button, YunoHost users search
+
+#### Plugins
+
+You can also install other plugins - which will not be removed with upgrades. To do so, you can use the official [Plugin Repository](https://plugins.roundcube.net/).
+
+##### From the Plugin Repository
+
+Let's say for example that we want to install the [html5_notifier](https://packagist.org/packages/kitist/html5_notifier) plugin.
+
+1. Connect to your server as root using SSH:
+   ```
+   $ ssh admin@1.2.3.4
+   $ sudo -i
+   ```
+
+2. Log in as the `roundcube` user - which owns the roundcube directory - and navigate in it:
+   ```
+   # su -s /bin/bash - roundcube
+   $ cd /var/www/roundcube
+   ```
+
+3. Install the plugin you want using composer - note that you have to specify *kitist/html5_notifier* and not only *html5_notifier*:
+   ```
+   $ COMPOSER_HOME=./.composer php composer.phar require "kitist/html5_notifier"
+   ```
+
+4. Enable it in the local configuration file `config/<DOMAIN>.inc.php` using your favorite text editor by adding:
+   ```
+   <?php
+   array_push($this->prop['plugins'], 'html5_notifier');
+   ```
+   See https://github.com/roundcube/roundcubemail/issues/9458.
+
+Note that you should also check the plugin homepage for additional installation steps as needed.
+
+##### Manual installation
+
+You can also download the plugin and put it under the `plugins/` directory. In this case, do not forget to change ownerships of this folder to `roundcube`.
+
 ## Documentation and resources
 
 - Official app website: <https://roundcube.net/>

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -187,3 +187,7 @@ $config['ldapAliasSync'] = array(
 
 // skin name: folder from skins/
 $config['skin'] = 'elastic';
+
+// -- config
+// Allow custom config
+$config['include_host_config'] = true;


### PR DESCRIPTION
## Problem

I am using 3 additional plugins in my roundcube instance. However, as I had to add them in `config/config.inc.php` after each update they get disabled and I have to enable them again manually (by adding the plugins back to `config/config.inc.php` which is annoying.

## Solution

Instead of adding plugins to `config/config.inc.php` enable option to add them to a custom config file `config/<ROUNDCUBE_DOMAIN>.inc.php` by adding `$config['include_host_config'] = true;` to `config/config.inc.php`.

With this setting additional plugins can be enabled like this in `config/<ROUNDCUBE_DOMAIN>.inc.php`:
```
array_push($this->prop['plugins'], 'html5_notifier');
```
See https://github.com/roundcube/roundcubemail/issues/9458#issuecomment-2121753923.

I have it working like this on my server flawlessly.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
