### PR TITLE
Upgrade PHP version to 8.2

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -69,15 +69,15 @@ ram.runtime = "50M"
     packages = [
         "mariadb-server",
         "php-pear",
-        "php8.1-ldap",
-        "php8.1-mysql",
-        "php8.1-cli",
-        "php8.1-intl",
-        "php8.1-zip",
-        "php8.1-gd",
-        "php8.1-mbstring",
-        "php8.1-dom",
-        "php8.1-curl",
+        "php8.2-ldap",
+        "php8.2-mysql",
+        "php8.2-cli",
+        "php8.2-intl",
+        "php8.2-zip",
+        "php8.2-gd",
+        "php8.2-mbstring",
+        "php8.2-dom",
+        "php8.2-curl",
     ]
 
     [resources.database]


### PR DESCRIPTION
## Problem

PHP 8.1 active support has ended 6 months ago. See https://www.php.net/supported-versions.php.

## Solution

Upgrade to PHP 8.2 which is officially supported by Roundcube.

> Version 1.6
Initial release: 28 July 2022
PHP support: >=7.3 <=8.3

See https://github.com/roundcube/roundcubemail/wiki/Version-History and https://github.com/roundcube/roundcubemail/issues/9339 .

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
