### PR TITLE
Stop using Elastic, change to elastic2022

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -186,4 +186,4 @@ $config['ldapAliasSync'] = array(
 );
 
 // skin name: folder from skins/
-$config['skin'] = 'larry';
+$config['skin'] = 'Elastic2022';

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -186,4 +186,4 @@ $config['ldapAliasSync'] = array(
 );
 
 // skin name: folder from skins/
-$config['skin'] = 'elastic';
+$config['skin'] = 'larry';

--- a/scripts/install
+++ b/scripts/install
@@ -84,6 +84,11 @@ ynh_script_progression --message="Installing additional plugins..." --weight=60
 # Create logs and temp directories
 mkdir -p "$install_dir/"{logs,temp}
 
+# Elastic2022 theme git clone + install
+mkdir -p "$install_dir/skins/Elastic2022"
+git clone https://github.com/seb1k/Elastic2022.git "$install_dir/skins/Elastic2022"
+chown -R $app:www-data "$install_dir/skins/Elastic2022" 
+
 # Install net_LDAP
 export COMPOSER_ALLOW_SUPERUSER=1
 ynh_composer_exec --commands="require kolab/net_ldap3"


### PR DESCRIPTION
## Problem

-Elastic theme is broken

## Solution

- Don't use Elastic, use something else, like Elastic2022
- I really just put the instructions from [this issue](https://github.com/YunoHost-Apps/roundcube_ynh/issues/204#issuecomment-2222857474) into the installation script. 
- The upgrade script may be broken by this change.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

I can't do automatic tests, please do one for me!

I DID install on my instance (Pi 4B 4GB) without issue, but I have not tested any edge cases.

Is this a terrible pull request? It doesn't fix the issue, it just moves away from the problem. I'm not capable enough to find the solution to the actual issue, and this has remained as an issue for some time, so I feel like this is an acceptable solution in the meantime. Feedback is appreciated.
