### PR TITLE
Change source back to release (was changed to  archives)

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -54,8 +54,8 @@ ram.runtime = "50M"
 
 [resources]
     [resources.sources.main]
-    url = "https://github.com/roundcube/roundcubemail/archive/refs/tags/1.6.7.tar.gz"
-    sha256 = "fe56c37485862b738e03ea3f91288178e36b4793a50dd6b832052d0b2b0e3fcd"
+    url = "https://github.com/roundcube/roundcubemail/releases/download/1.6.7/roundcubemail-1.6.7.tar.gz"
+    sha256 = "b12c4f9f84890830ce10e470ac0d698b7de00d29f432a9326b4cf8c590e558de"
     autoupdate.strategy = "latest_github_release"
 
     [resources.system_user]

--- a/manifest.toml
+++ b/manifest.toml
@@ -57,6 +57,7 @@ ram.runtime = "50M"
     url = "https://github.com/roundcube/roundcubemail/releases/download/1.6.7/roundcubemail-1.6.7.tar.gz"
     sha256 = "b12c4f9f84890830ce10e470ac0d698b7de00d29f432a9326b4cf8c590e558de"
     autoupdate.strategy = "latest_github_release"
+    autoupdate.asset = "roundcubemail-.*.tar.gz"
 
     [resources.system_user]
 


### PR DESCRIPTION
## Problem

- *Fixes https://github.com/YunoHost-Apps/roundcube_ynh/issues/204* that was caused by commit https://github.com/YunoHost-Apps/roundcube_ynh/commit/dccb989e9d4334bb040e88677321dd387a3604f0#diff-06ac558c9cfca9e31a9a235f18d98e6d0c3bfee8bee0088108a29f2c60b318e3 that changed the source from releases file to archive file.

## Solution

- *I set the source back to release files instead of archives of the repo*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (on my own instance)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
