### PR TITLE
fix: correctly load identity from LDAP 

### DIFF
--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -117,8 +117,14 @@ $config['ldap_public']['yunohost'] = array(
   'filter' => '(objectClass=mailAccount)',
   'hidden' => false,
   'searchonly' => true,
+  'search_fields' => array(
+    'uid',
+    'mail',
+    'cn'
+  ),
   'fieldmap' => array(
-    'name'      => 'uid',
+    'uid'       => 'uid',
+    'name'      => 'cn',
     'surname'   => 'sn',
     'firstname' => 'givenName',
     'email'     => 'mail:*',
@@ -148,6 +154,8 @@ $config['plugins'] = array(
 // The id of the address book to use to automatically set a
 // user's full name in their new identity.
 $config['new_user_identity_addressbook'] = 'yunohost';
+$config['new_user_identity_match'] = 'uid';
+$config['new_user_identity_onlogin'] = true;
 
 // -- http_authentication
 // Redirect the client to this URL after logout.

--- a/conf/config.inc.php
+++ b/conf/config.inc.php
@@ -116,7 +116,6 @@ $config['ldap_public']['yunohost'] = array(
   'scope' => 'list',
   'filter' => '(objectClass=mailAccount)',
   'hidden' => false,
-  'searchonly' => true,
   'search_fields' => array(
     'uid',
     'mail',


### PR DESCRIPTION
## Problem

When opening Roundcube as a new user, it always displays the logged-in user uid as the name and <uid>@localhost as the email, which is quite disappointing.
It's possible to directly fetch the name and email from the LDAP just by configuring well the LDAP plugin.

![Capture d’écran 2025-01-02 191353](https://github.com/user-attachments/assets/56498d37-410d-449b-8600-b8548d8f2b4c)

## Solution

My goal was to make the ldap identity plugin to fetch the user by its `uid`.
To do so, it has to be in `search_fields`, and in `fields_map` (even if it's not displayed by Roundcube).
BTW I also disabled `search_only` to fetch the complete list of users.

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

Tested it on my server and it now works like a charm.

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
