### PR TITLE
fix #233 nextcloud carddav default configuration

### DIFF
--- a/conf/nextcloud.inc.php
+++ b/conf/nextcloud.inc.php
@@ -1,10 +1,11 @@
 
 $prefs['{nextcloud_id}'] = array(
         // required attributes
-        'name'         =>  '{nextcloud_id}',
+        'accountname'         =>  '{nextcloud_id} addressbooks',
         'username'     =>  '%u',
         'password'     =>  '%p',
-        'url'          =>  '{nextcloud_url}/remote.php/dav/addressbooks/users/%u/contacts/',
+        'discovery_url'          =>  '{nextcloud_url}/remote.php/dav/addressbooks/users/%u/',
+        'rediscover_time' => '12:09:00',
 
         // optional attributes
         'active'       =>  true,


### PR DESCRIPTION
## Problem

Cf #233

## Solution

Changed Nextcloud Carddav default configuration to handle addressbook discovery

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
