### PR TITLE
Update carddav version to 5.1.2

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -10,7 +10,7 @@ YNH_COMPOSER_VERSION=2.5.5
 # Plugins version
 contextmenu_version=3.3.1
 automatic_addressbook_version=v0.4.3
-carddav_version=5.1.0
+carddav_version=5.1.2
 
 #=================================================
 # EXPERIMENTAL HELPERS


### PR DESCRIPTION
## Problem

Outdated carddav version 5.1.0 from 19th August 2023.

## Solution

Upgrade carddav version to 5.1.2 from 30th September 2025. See versions https://plugins.roundcube.net/#/packages/roundcube/carddav.

Version 5.1.1 and  5.1.2 don't seem to include breaking changes. See https://github.com/mstilkerich/rcmcarddav/releases.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
